### PR TITLE
Improve move validations and add concurrency coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,18 @@
 			<artifactId>postgresql</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/iulii/records_mover/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/iulii/records_mover/controller/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.iulii.records_mover.controller;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.Instant;
+import java.util.ConcurrentModificationException;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({IllegalArgumentException.class, MethodArgumentTypeMismatchException.class,
+            MethodArgumentNotValidException.class, BindException.class})
+    public ResponseEntity<Map<String, Object>> handleBadRequest(Exception ex) {
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleNotFound(EntityNotFoundException ex) {
+        return buildResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(ConcurrentModificationException.class)
+    public ResponseEntity<Map<String, Object>> handleConflict(ConcurrentModificationException ex) {
+        return buildResponse(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleUnhandled(Exception ex) {
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Unexpected error: " + ex.getMessage());
+    }
+
+    private ResponseEntity<Map<String, Object>> buildResponse(HttpStatus status, String message) {
+        return ResponseEntity.status(status)
+                .body(Map.of(
+                        "timestamp", Instant.now().toString(),
+                        "status", status.value(),
+                        "error", status.getReasonPhrase(),
+                        "message", message
+                ));
+    }
+}

--- a/src/main/java/com/iulii/records_mover/controller/RecordsController.java
+++ b/src/main/java/com/iulii/records_mover/controller/RecordsController.java
@@ -26,6 +26,18 @@ public class RecordsController {
             @RequestParam(required = false) UUID after,
             @RequestParam(required = false) UUID before) {
 
+        if (after == null && before == null) {
+            throw new IllegalArgumentException("Either 'after' or 'before' parameter must be provided");
+        }
+
+        if ((after != null && after.equals(id)) || (before != null && before.equals(id))) {
+            throw new IllegalArgumentException("Item cannot be moved relative to itself");
+        }
+
+        if (after != null && before != null && after.equals(before)) {
+            throw new IllegalArgumentException("'after' and 'before' cannot reference the same item");
+        }
+
         service.moveItemBetween(id, after, before);
         return ResponseEntity.ok().build();
     }
@@ -35,5 +47,14 @@ public class RecordsController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "50") int size) {
 
-        return service.getRecords(page, size);}
+        if (page < 0) {
+            throw new IllegalArgumentException("Page index must not be negative");
+        }
+
+        if (size <= 0 || size > 500) {
+            throw new IllegalArgumentException("Size must be between 1 and 500");
+        }
+
+        return service.getRecords(page, size);
+    }
 }

--- a/src/main/java/com/iulii/records_mover/service/RecordsService.java
+++ b/src/main/java/com/iulii/records_mover/service/RecordsService.java
@@ -42,20 +42,30 @@ public class RecordsService {
     @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 50), retryFor = ConcurrentModificationException.class)
     @Transactional(isolation = Isolation.REPEATABLE_READ)
     public void moveItemBetween(UUID itemId, UUID afterId, UUID beforeId) {
-        // Блокируем перемещаемый элемент и соседей
-        MovableRecord itemToMove = repository.findByIdWithLock(itemId).orElseThrow(() -> new EntityNotFoundException("Item not found"));
+        repository.findByIdWithLock(itemId)
+                .orElseThrow(() -> new EntityNotFoundException("Item not found"));
 
-        NeighborPositions neighborPositions = getNeighborPositions(afterId, beforeId);
+        NeighborContext neighborContext = getNeighborContext(afterId, beforeId);
 
-        Double newPosition = findAvailablePosition(neighborPositions.afterPos, neighborPositions.beforePos);
+        Double newPosition = findAvailablePosition(neighborContext.afterPos(), neighborContext.beforePos());
 
-        //  Проверяем, что позиция свободна (дополнительная защита)
+        neighborContext = refreshNeighborContext(neighborContext);
+
         if (repository.existsByPosition(newPosition)) {
             throw new ConcurrentModificationException("Position was occupied after calculation");
         }
 
-        //  Атомарное обновление с проверкой
-        repository.updatePosition(itemId, newPosition);
+        int updated = repository.updatePositionSafely(
+                itemId,
+                newPosition,
+                neighborContext.afterId(),
+                neighborContext.afterPos(),
+                neighborContext.beforeId(),
+                neighborContext.beforePos());
+
+        if (updated == 0) {
+            throw new ConcurrentModificationException("Unable to update position due to concurrent changes");
+        }
     }
 
     // Рекурсивный поиск доступной позиции
@@ -86,10 +96,16 @@ public class RecordsService {
         double existingGap = beforePos - afterPos;
         double shiftAmount = requiredGap - existingGap;
 
+        if (shiftAmount <= 0) {
+            return afterPos + (beforePos - afterPos) / 2;
+        }
+
         // Пакетный сдвиг с блокировками
         shift500ItemsInBatches(beforePos, shiftAmount);
 
-        return afterPos + (requiredGap / 2);
+        double widenedBeforePos = beforePos + shiftAmount;
+
+        return afterPos + (widenedBeforePos - afterPos) / 2;
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -99,16 +115,48 @@ public class RecordsService {
         repository.saveAll(batch);
     }
 
-    private NeighborPositions getNeighborPositions(UUID afterId, UUID beforeId) {
-        Double afterPos = afterId != null ? repository.findByIdWithLock(afterId).orElseThrow(() -> new EntityNotFoundException("After item not found")).getPosition() : 0;
+    private NeighborContext getNeighborContext(UUID afterId, UUID beforeId) {
+        Double afterPos = null;
+        if (afterId != null) {
+            afterPos = repository.findByIdWithLock(afterId)
+                    .orElseThrow(() -> new EntityNotFoundException("After item not found"))
+                    .getPosition();
+        }
 
-        Double beforePos = beforeId != null ? repository.findByIdWithLock(beforeId).orElseThrow(() -> new EntityNotFoundException("Before item not found")).getPosition() : repository.findMaxPosition() + 100;
+        Double beforePos;
+        if (beforeId != null) {
+            beforePos = repository.findByIdWithLock(beforeId)
+                    .orElseThrow(() -> new EntityNotFoundException("Before item not found"))
+                    .getPosition();
+        } else {
+            Double maxPosition = repository.findMaxPosition();
+            beforePos = (maxPosition != null ? maxPosition : 0.0) + 100;
+        }
 
-        return new NeighborPositions(afterPos, beforePos);
+        double afterPositionValue = afterPos != null ? afterPos : 0.0;
+
+        return new NeighborContext(afterId, afterPositionValue, beforeId, beforePos);
+    }
+
+    private NeighborContext refreshNeighborContext(NeighborContext context) {
+        Double refreshedAfterPos = context.afterPos();
+        if (context.afterId() != null) {
+            refreshedAfterPos = repository.findByIdWithLock(context.afterId())
+                    .orElseThrow(() -> new EntityNotFoundException("After item not found"))
+                    .getPosition();
+        }
+
+        Double refreshedBeforePos = context.beforePos();
+        if (context.beforeId() != null) {
+            refreshedBeforePos = repository.findByIdWithLock(context.beforeId())
+                    .orElseThrow(() -> new EntityNotFoundException("Before item not found"))
+                    .getPosition();
+        }
+
+        return new NeighborContext(context.afterId(), refreshedAfterPos, context.beforeId(), refreshedBeforePos);
     }
 
 
-    //Рекорд для хранения позиций между которых перемещаем для удобства
-    private record NeighborPositions(Double afterPos, Double beforePos) {
+    private record NeighborContext(UUID afterId, Double afterPos, UUID beforeId, Double beforePos) {
     }
 }

--- a/src/test/java/com/iulii/records_mover/RecordsMoverApplicationTests.java
+++ b/src/test/java/com/iulii/records_mover/RecordsMoverApplicationTests.java
@@ -2,8 +2,10 @@ package com.iulii.records_mover;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class RecordsMoverApplicationTests {
 
 	@Test

--- a/src/test/java/com/iulii/records_mover/controller/RecordsControllerTest.java
+++ b/src/test/java/com/iulii/records_mover/controller/RecordsControllerTest.java
@@ -1,0 +1,96 @@
+package com.iulii.records_mover.controller;
+
+import com.iulii.records_mover.models.MovableRecord;
+import com.iulii.records_mover.service.RecordsService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RecordsController.class)
+class RecordsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RecordsService recordsService;
+
+    @Test
+    void moveItem_shouldValidateRequiredBoundaries() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(post("/api/items/" + id + "/move"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString("Either 'after' or 'before' parameter must be provided")));
+    }
+
+    @Test
+    void moveItem_shouldPropagateNotFound() throws Exception {
+        UUID id = UUID.randomUUID();
+        UUID after = UUID.randomUUID();
+
+        Mockito.doThrow(new EntityNotFoundException("Item not found"))
+                .when(recordsService).moveItemBetween(id, after, null);
+
+        mockMvc.perform(post("/api/items/" + id + "/move").param("after", after.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(containsString("Item not found")));
+    }
+
+    @Test
+    void moveItem_shouldTranslateConcurrentModification() throws Exception {
+        UUID id = UUID.randomUUID();
+        UUID after = UUID.randomUUID();
+        UUID before = UUID.randomUUID();
+
+        Mockito.doThrow(new ConcurrentModificationException("conflict"))
+                .when(recordsService).moveItemBetween(id, after, before);
+
+        mockMvc.perform(post("/api/items/" + id + "/move")
+                        .param("after", after.toString())
+                        .param("before", before.toString()))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(containsString("conflict")));
+    }
+
+    @Test
+    void getRecords_shouldValidatePageRequest() throws Exception {
+        mockMvc.perform(get("/api/items")
+                        .param("page", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString("Page index must not be negative")));
+
+        mockMvc.perform(get("/api/items")
+                        .param("size", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString("Size must be between 1 and 500")));
+    }
+
+    @Test
+    void getRecords_shouldReturnPage() throws Exception {
+        Page<MovableRecord> page = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 10), 0);
+        Mockito.when(recordsService.getRecords(0, 10)).thenReturn(page);
+
+        mockMvc.perform(get("/api/items").param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+}

--- a/src/test/java/com/iulii/records_mover/service/RecordsServiceIntegrationTest.java
+++ b/src/test/java/com/iulii/records_mover/service/RecordsServiceIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.iulii.records_mover.service;
+
+import com.iulii.records_mover.models.MovableRecord;
+import com.iulii.records_mover.repository.RecordsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RecordsServiceIntegrationTest {
+
+    @Autowired
+    private RecordsService recordsService;
+
+    @Autowired
+    private RecordsRepository repository;
+
+    @BeforeEach
+    void clean() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void moveItemBetween_shouldShiftBatchWhenGapIsTooSmall() {
+        MovableRecord after = saveRecord(1.0);
+        MovableRecord before = saveRecord(1.00000000005);
+        MovableRecord extra = saveRecord(1.0000000001);
+        MovableRecord toMove = saveRecord(5.0);
+
+        recordsService.moveItemBetween(toMove.getId(), after.getId(), before.getId());
+
+        MovableRecord refreshedBefore = repository.findById(before.getId()).orElseThrow();
+        MovableRecord refreshedExtra = repository.findById(extra.getId()).orElseThrow();
+        MovableRecord refreshedMoved = repository.findById(toMove.getId()).orElseThrow();
+
+        assertThat(refreshedBefore.getPosition()).isGreaterThan(1.00000000005);
+        assertThat(refreshedExtra.getPosition()).isGreaterThan(1.0000000001);
+        assertThat(refreshedMoved.getPosition())
+                .isGreaterThan(after.getPosition())
+                .isLessThan(refreshedBefore.getPosition());
+    }
+
+    @Test
+    void concurrentMoves_shouldAssignUniquePositions() throws ExecutionException, InterruptedException {
+        MovableRecord anchor = saveRecord(1.0);
+        MovableRecord boundary = saveRecord(100.0);
+
+        List<MovableRecord> movableRecords = IntStream.range(0, 5)
+                .mapToObj(i -> saveRecord(200.0 + i))
+                .toList();
+
+        List<CompletableFuture<Void>> futures = movableRecords.stream()
+                .map(record -> CompletableFuture.runAsync(() ->
+                        recordsService.moveItemBetween(record.getId(), anchor.getId(), boundary.getId())))
+                .toList();
+
+        for (CompletableFuture<Void> future : futures) {
+            future.get();
+        }
+
+        List<Double> positions = movableRecords.stream()
+                .map(record -> repository.findById(record.getId()).orElseThrow().getPosition())
+                .toList();
+
+        long movedIntoRange = repository.findAll().stream()
+                .filter(record -> record.getPosition() > anchor.getPosition() && record.getPosition() < boundary.getPosition())
+                .count();
+
+        assertThat(positions).allMatch(pos -> pos > anchor.getPosition() && pos < boundary.getPosition());
+        assertThat(movedIntoRange).isGreaterThanOrEqualTo(movableRecords.size());
+    }
+
+    private MovableRecord saveRecord(double position) {
+        MovableRecord record = new MovableRecord();
+        record.setValue("value-" + position);
+        record.setPosition(position);
+        MovableRecord saved = repository.save(record);
+        repository.flush();
+        return saved;
+    }
+}

--- a/src/test/java/com/iulii/records_mover/service/RecordsServiceTest.java
+++ b/src/test/java/com/iulii/records_mover/service/RecordsServiceTest.java
@@ -85,12 +85,14 @@ class RecordsServiceTest {
         when(repository.findByIdWithLock(afterId)).thenReturn(Optional.of(afterRecord));
         when(repository.findByIdWithLock(beforeId)).thenReturn(Optional.of(beforeRecord));
         when(repository.existsByPosition(1.5)).thenReturn(false);
+        when(repository.updatePositionSafely(eq(itemId), anyDouble(), eq(afterId), eq(afterRecord.getPosition()), eq(beforeId), eq(beforeRecord.getPosition())))
+                .thenReturn(1);
 
         // Act
         recordsService.moveItemBetween(itemId, afterId, beforeId);
 
         // Assert
-        verify(repository).updatePosition(itemId, 1.5);
+        verify(repository).updatePositionSafely(eq(itemId), eq(1.5), eq(afterId), eq(afterRecord.getPosition()), eq(beforeId), eq(beforeRecord.getPosition()));
     }
 
     @Test
@@ -134,12 +136,24 @@ class RecordsServiceTest {
         when(repository.findByIdWithLock(afterId)).thenReturn(Optional.of(afterRecord));
         when(repository.findByIdWithLock(beforeId)).thenReturn(Optional.of(tightBeforeRecord));
         when(repository.existsByPosition(1.0000000005)).thenReturn(false);
+        when(repository.updatePositionSafely(any(), anyDouble(), any(), anyDouble(), any(), anyDouble())).thenReturn(1);
 
         // Act
         recordsService.moveItemBetween(itemId, afterId, beforeId);
 
         // Assert
         verify(repository).findAndLockNextItemsById(any(), any(), any());
+    }
+
+    @Test
+    void moveItemBetween_shouldThrowWhenSafeUpdateFails() {
+        when(repository.findByIdWithLock(itemId)).thenReturn(Optional.of(movableRecord));
+        when(repository.findByIdWithLock(afterId)).thenReturn(Optional.of(afterRecord));
+        when(repository.findByIdWithLock(beforeId)).thenReturn(Optional.of(beforeRecord));
+        when(repository.existsByPosition(1.5)).thenReturn(false);
+        when(repository.updatePositionSafely(any(), anyDouble(), any(), anyDouble(), any(), anyDouble())).thenReturn(0);
+
+        assertThrows(ConcurrentModificationException.class, () -> recordsService.moveItemBetween(itemId, afterId, beforeId));
     }
 
     @Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=VALUE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC


### PR DESCRIPTION
## Summary
- add request validation and global exception handling to the records API
- harden concurrent move logic to use the safe update path and refreshed neighbor locks
- introduce H2-backed integration tests plus controller/unit coverage for move and listing endpoints

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68e1a87a8a5c8329a493e1917c574c74